### PR TITLE
fix: パス・トラバーサル脆弱性対策としてファイル名の検証を追加

### DIFF
--- a/src/main/java/com/example/vuln/service/FileService.java
+++ b/src/main/java/com/example/vuln/service/FileService.java
@@ -21,6 +21,11 @@ public class FileService {
      * @throws IOException
      */
     public String readStaticLfi(String fileName) throws IOException {
+        // パス・トラバーサル対策: ファイル名に不正な文字列が含まれていないかチェック
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            return "不正なファイル名です。";
+        }
+
         try {
             Path filePath = Paths.get("src/main/resources/static/lfi/" + fileName);
             return Files.lines(filePath, StandardCharsets.UTF_8)


### PR DESCRIPTION
FileServiceのreadStaticLfiメソッドにおいて、パス・トラバーサル攻撃を防ぐためにファイル名に不正な文字列が含まれていないかチェックするバリデーションを追加しました。これにより、../や/などの文字列が含まれるファイル名でのアクセスを防止します。