### PR TITLE
fix: パス・トラバーサル脆弱性対策としてファイル名の検証を追加

### DIFF
--- a/src/main/java/com/example/vuln/service/FileService.java
+++ b/src/main/java/com/example/vuln/service/FileService.java
@@ -21,8 +21,14 @@ public class FileService {
      * @throws IOException
      */
     public String readStaticLfi(String fileName) throws IOException {
+        if (fileName.contains("..") || fileName.contains("/")) {
+            return "不正なファイル名です。";
+        }
         try {
-            Path filePath = Paths.get("src/main/resources/static/lfi/" + fileName);
+            Path filePath = Paths.get("src/main/resources/static/lfi/" + fileName).normalize();
+            if (!filePath.startsWith(Paths.get("src/main/resources/static/lfi/"))) {
+                return "不正なファイル名です。";
+            }
             return Files.lines(filePath, StandardCharsets.UTF_8)
                     .collect(Collectors.joining("\n"));
         } catch ( NoSuchFileException ex ) {


### PR DESCRIPTION
FileServiceのreadStaticLfiメソッドにて、パス・トラバーサル攻撃の対策を追加しました。
- ファイル名に".."や"/"が含まれている場合は不正なファイル名として処理
- ファイルパスを正規化し、指定ディレクトリの外に出ていないかをチェック

これにより、悪意のあるファイルパスによる任意ファイル読み込みの脆弱性を防止します。